### PR TITLE
version(): Add logic to catch the attribut when calling fct

### DIFF
--- a/bashlava.sh
+++ b/bashlava.sh
@@ -221,7 +221,7 @@ function pr { # User_
   _pr_title=$(git log --format=%B -n 1 "$(git log -1 --pretty=format:"%h")" | cat -)
   _var_name="_pr_title" _is_it_empty="${_pr_title}" && Condition_Vars_Must_Be_Not_Empty
 
-  gh pr create --fill --title "${_pr_title}" --base "${default_branch}"
+  gh pr create --fill --title "${_pr_title}" --base "${default_branch}" && sleep 1
   gh pr view --web    # if there is a bug see: /docs/debug_upstream.md
 
   _doc_name="next_move_fct_pr.md" && Show_Docs

--- a/bashlava.sh
+++ b/bashlava.sh
@@ -12,19 +12,11 @@ PINNED issues on GH             _
   issue #10 Logic & Condition   _
   issue #11 docs                _
                                 _
-PR Title: New Feat:            
-Impact on: #4, #8, #9 #10
+PR Title: New Feat: 0o0o
+- 0o0o
+- 0o0o
+- Impact on: #4, #8, #9 #10
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-
-TODO
-PR Title: New feat: tci(): tag to trigger the CI
-Impact on: #4, #8
-
-- User facing
-- Now, main_branch builds only when pushing tags
-- Now, the CI do not build on every commits on main_branch (its a pain when we merge many PRs)
-- Sometime we work directly on the main_branch (typically for CI work) and we dont want to trigger the CI pipeline
 
 
 TODO edge()
@@ -358,7 +350,7 @@ function tci { # User_
   git tag ${_tag_name} && git push --tags && echo
   Show_Version
 
-  # For docs, see this PR: 0o0o
+  # See this PR: https://github.com/firepress-org/bashlava/pulls?q=is%3Apr+is%3Aclosed+tci
 }
 
 function release { # User_


### PR DESCRIPTION
## major
PR Title: version(): Add logic to catch the attribut when calling fct 
- Add logic to consider the fact that user may add the attribut version like /v 1.4.16/
- Now the attributes is ignored
- Fully Idempotent, great!
- Impact on: #4, #8
- Bug fix: version(), Impact on: #9

## minor
- tci() Add comments
- pr() Add some delay before openning URL

